### PR TITLE
fix: disable search textbox in layers panel to resolve issue #22

### DIFF
--- a/apps/web/src/components/elements/layers.tsx
+++ b/apps/web/src/components/elements/layers.tsx
@@ -194,6 +194,8 @@ function ElementLayers() {
 						selectedItems
 					}
 				}}
+				canSearch={false}
+				canSearchByStartingTyping={false}
 				onFocusItem={(item) => setFocusedItem(item.index)}
 				onExpandItem={(item) =>
 					setExpandedItems([...expandedItems, item.index])


### PR DESCRIPTION
### **User description**
- Added canSearch={false} and canSearchByStartingTyping={false} to ControlledTreeEnvironment
- Prevents unwanted search textbox from appearing when typing in layers panel
- Improves user experience by eliminating accidental search activation


___

### **PR Type**
Bug fix


___

### **Description**
- Disable search functionality in layers panel tree component

- Prevent accidental search textbox activation when typing

- Improve user experience by removing unwanted search behavior


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User types in layers panel"] --> B["Search textbox appears accidentally"]
  B --> C["canSearch={false} added"]
  C --> D["canSearchByStartingTyping={false} added"]
  D --> E["Search textbox disabled"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layers.tsx</strong><dd><code>Disable tree search functionality in layers component</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/elements/layers.tsx

<li>Added <code>canSearch={false}</code> property to ControlledTreeEnvironment<br> <li> Added <code>canSearchByStartingTyping={false}</code> property to disable search on <br>typing<br> <li> Prevents unwanted search textbox from appearing in layers panel


</details>


  </td>
  <td><a href="https://github.com/windbase/windbase/pull/36/files#diff-077ba380d43823f1739f7bbf13cfa1cf1d202545466d98b36558e0beea4bbd0f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>