### PR TITLE
fix: preserve selection on undo/redo when element still exists [skip ci]

### DIFF
--- a/packages/engine/src/history/index.ts
+++ b/packages/engine/src/history/index.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand';
+import { findElementById } from '../store/helpers';
 import type { BuilderStore, HistorySlice } from '../store/types';
 
 export const createHistorySlice: StateCreator<
@@ -34,7 +35,7 @@ export const createHistorySlice: StateCreator<
 				if (
 					state.history.length > 0 &&
 					JSON.stringify(state.history[state.history.length - 1]) ===
-						JSON.stringify(currentElements)
+					JSON.stringify(currentElements)
 				) {
 					return;
 				}
@@ -74,7 +75,7 @@ export const createHistorySlice: StateCreator<
 			if (
 				state.history.length > 0 &&
 				JSON.stringify(state.history[state.history.length - 1]) ===
-					JSON.stringify(currentElements)
+				JSON.stringify(currentElements)
 			) {
 				return;
 			}
@@ -109,11 +110,20 @@ export const createHistorySlice: StateCreator<
 					state.updatePage(currentPage.id, { elements: elementsToRestore });
 				}
 
+				// Check if selected element still exists in restored state
+				let selectedElement = state.selectedElement;
+				if (selectedElement) {
+					const selectedStillExists = findElementById(elementsToRestore, selectedElement.id);
+					if (!selectedStillExists) {
+						selectedElement = null;
+					}
+				}
+
 				set({
 					historyIndex: newIndex,
 					canUndo: newIndex > 0,
 					canRedo: true,
-					selectedElement: null // Clear selection after undo
+					selectedElement
 				});
 			}
 		},
@@ -131,11 +141,20 @@ export const createHistorySlice: StateCreator<
 					state.updatePage(currentPage.id, { elements: elementsToRestore });
 				}
 
+				// Check if selected element still exists in restored state
+				let selectedElement = state.selectedElement;
+				if (selectedElement) {
+					const selectedStillExists = findElementById(elementsToRestore, selectedElement.id);
+					if (!selectedStillExists) {
+						selectedElement = null;
+					}
+				}
+
 				set({
 					historyIndex: newIndex,
 					canUndo: true,
 					canRedo: newIndex < state.history.length - 1,
-					selectedElement: null // Clear selection after redo
+					selectedElement
 				});
 			}
 		}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Preserve element selection during undo/redo operations

- Check if selected element exists after state restoration

- Clear selection only when element no longer exists


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Undo/Redo Action"] --> B["Restore Elements State"]
  B --> C["Check Selected Element"]
  C --> D{"Element Still Exists?"}
  D -->|Yes| E["Preserve Selection"]
  D -->|No| F["Clear Selection"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Preserve selection during undo/redo operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/engine/src/history/index.ts

<li>Import <code>findElementById</code> helper function<br> <li> Add selection preservation logic in undo/redo methods<br> <li> Check if selected element exists after state restoration<br> <li> Clear selection only when element no longer exists


</details>


  </td>
  <td><a href="https://github.com/windbase/windbase/pull/55/files#diff-5fff92e8cedb1eae441f4ce08a906972f62a4ddf5e8e288f691519f09ac17d09">+23/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>